### PR TITLE
Adiciona Camada de Persistência e Classe Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ O sistema de coleções fornece uma API fluente e poderosa para manipular arrays
 **Exemplo com `ArrayList`:**
 
 ```php
-use jayroncastro\jfphp\ArrayList;
+use jayroncastro\jfphp\collections\ArrayList;
 
 $lista = new ArrayList(['PHP', 'JavaScript']);
 $lista->add('Python');
@@ -96,8 +96,9 @@ $lista->add('Python');
 ```
 
 **Exemplo com `HashSet`:**
+
 ```php
-use jayroncastro\jfphp\HashSet;
+use jayroncastro\jfphp\collections\HashSet;
 
 $set = new HashSet();
 $set->add('vermelho'); // true (adicionado)

--- a/src/collections/AbstractCollection.php
+++ b/src/collections/AbstractCollection.php
@@ -6,10 +6,8 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html
  * @link https://github.com/jayroncastro/jfphp
  */
-namespace jayroncastro\jfphp;
+namespace jayroncastro\jfphp\collections;
 
-use jayroncastro\jfphp\CollectionInterface;
-use ReturnTypeWillChange;
 use Traversable;
 
 /**
@@ -19,7 +17,7 @@ use Traversable;
  * @template TValue
  * @implements CollectionInterface<TValue>
  * @package jayroncastro
- * @subpackage jfphp
+ * @subpackage jfphp/collections
  * @since 1.0.0
  * @version 1.0.0
  */

--- a/src/collections/AbstractList.php
+++ b/src/collections/AbstractList.php
@@ -6,11 +6,9 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html
  * @link https://github.com/jayroncastro/jfphp
  */
-namespace jayroncastro\jfphp;
+namespace jayroncastro\jfphp\collections;
 
-use jayroncastro\jfphp\AbstractCollection;
 use jayroncastro\jfphp\exception\IndexOutOfBoundsException;
-use jayroncastro\jfphp\ListInterface;
 
 /**
  * This abstract class extends `AbstractCollection` and implements
@@ -21,7 +19,7 @@ use jayroncastro\jfphp\ListInterface;
  * @implements ListInterface<TValue>
  * @extends AbstractCollection
  * @package jayroncastro
- * @subpackage jfphp
+ * @subpackage jfphp/collections
  * @since 1.0.0
  * @version 1.0.0
  */

--- a/src/collections/AbstractSet.php
+++ b/src/collections/AbstractSet.php
@@ -6,10 +6,7 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html
  * @link https://github.com/jayroncastro/jfphp
  */
-namespace jayroncastro\jfphp;
-
-use jayroncastro\jfphp\AbstractCollection;
-use jayroncastro\jfphp\SetInterface;
+namespace jayroncastro\jfphp\collections;
 
 /**
  * This abstract class provides the base implementation for
@@ -19,7 +16,7 @@ use jayroncastro\jfphp\SetInterface;
  * @implements SetInterface
  * @extends AbstractCollection<TValue>
  * @package jayroncastro
- * @subpackage jfphp
+ * @subpackage jfphp/collections
  * @since 1.0.0
  * @version 1.0.0
  */

--- a/src/collections/ArrayList.php
+++ b/src/collections/ArrayList.php
@@ -17,7 +17,6 @@ namespace jayroncastro\jfphp\collections;
  * @subpackage jfphp/collections
  * @since 1.0.0
  * @version 1.0.0
- * @final
  */
 final class ArrayList extends AbstractList {
 

--- a/src/collections/ArrayList.php
+++ b/src/collections/ArrayList.php
@@ -6,9 +6,7 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html
  * @link https://github.com/jayroncastro/jfphp
  */
-namespace jayroncastro\jfphp;
-
-use jayroncastro\jfphp\AbstractList;
+namespace jayroncastro\jfphp\collections;
 
 /**
  * Array-based list implementation. Inherits all functionality
@@ -16,10 +14,11 @@ use jayroncastro\jfphp\AbstractList;
  * @template TValue
  * @extends AbstractList<TValue>
  * @package jayroncastro
- * @subpackage jfphp
+ * @subpackage jfphp/collections
  * @since 1.0.0
  * @version 1.0.0
+ * @final
  */
-class ArrayList extends AbstractList {
+final class ArrayList extends AbstractList {
 
 }

--- a/src/collections/ArrayListIterator.php
+++ b/src/collections/ArrayListIterator.php
@@ -22,7 +22,6 @@ use jayroncastro\jfphp\exception\NoSuchElementException;
  * @subpackage jfphp/collections
  * @since 1.0.0
  * @version 1.0.0
- * @final
  */
 final class ArrayListIterator implements ListIteratorInterface {
 

--- a/src/collections/ArrayListIterator.php
+++ b/src/collections/ArrayListIterator.php
@@ -6,12 +6,11 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html
  * @link https://github.com/jayroncastro/jfphp
  */
-namespace jayroncastro\jfphp;
+namespace jayroncastro\jfphp\collections;
 
 use jayroncastro\jfphp\exception\IllegalStateException;
 use jayroncastro\jfphp\exception\IndexOutOfBoundsException;
 use jayroncastro\jfphp\exception\NoSuchElementException;
-use jayroncastro\jfphp\ListIteratorInterface;
 
 /**
  * Implementation of `ListIteratorInterface` that allows you to
@@ -20,11 +19,12 @@ use jayroncastro\jfphp\ListIteratorInterface;
  * @template TValue
  * @implements ListIteratorInterface<TValue>
  * @package jayroncastro
- * @subpackage jfphp
+ * @subpackage jfphp/collections
  * @since 1.0.0
  * @version 1.0.0
+ * @final
  */
-class ArrayListIterator implements ListIteratorInterface {
+final class ArrayListIterator implements ListIteratorInterface {
 
     /**
      * The list we are iterating over.

--- a/src/collections/CollectionInterface.php
+++ b/src/collections/CollectionInterface.php
@@ -6,7 +6,7 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html
  * @link https://github.com/jayroncastro/jfphp
  */
-namespace jayroncastro\jfphp;
+namespace jayroncastro\jfphp\collections;
 
 use Countable;
 use IteratorAggregate;
@@ -19,7 +19,7 @@ use Traversable;
  * @extends IteratorAggregate
  * @extends Countable
  * @package jayroncastro
- * @subpackage jfphp
+ * @subpackage jfphp/collections
  * @since 1.0.0
  * @version 1.0.0
  */

--- a/src/collections/HashSet.php
+++ b/src/collections/HashSet.php
@@ -6,9 +6,7 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html
  * @link https://github.com/jayroncastro/jfphp
  */
-namespace jayroncastro\jfphp;
-
-use jayroncastro\jfphp\AbstractSet;
+namespace jayroncastro\jfphp\collections;
 
 /**
  * Implementation of `SetInterface` based on a hash table (array).
@@ -17,10 +15,11 @@ use jayroncastro\jfphp\AbstractSet;
  * @template TValue
  * @extends AbstractSet<TValue>
  * @package jayroncastro
- * @subpackage jfphp
+ * @subpackage jfphp/collections
  * @since 1.0.0
  * @version 1.0.0
+ * @final
  */
-class HashSet extends AbstractSet {
+final class HashSet extends AbstractSet {
     // No additional logic is needed here for the base functionality.
 }

--- a/src/collections/HashSet.php
+++ b/src/collections/HashSet.php
@@ -18,7 +18,6 @@ namespace jayroncastro\jfphp\collections;
  * @subpackage jfphp/collections
  * @since 1.0.0
  * @version 1.0.0
- * @final
  */
 final class HashSet extends AbstractSet {
     // No additional logic is needed here for the base functionality.

--- a/src/collections/ListInterface.php
+++ b/src/collections/ListInterface.php
@@ -6,7 +6,7 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html
  * @link https://github.com/jayroncastro/jfphp
  */
-namespace jayroncastro\jfphp;
+namespace jayroncastro\jfphp\collections;
 
 use jayroncastro\jfphp\exception\IndexOutOfBoundsException;
 
@@ -16,7 +16,7 @@ use jayroncastro\jfphp\exception\IndexOutOfBoundsException;
  * accessed by their integer index, that is, their position in the list,
  * as well as iterating over the elements in the list.
  * @package jayroncastro
- * @subpackage jfphp
+ * @subpackage jfphp/collections
  * @template TValue The type of value the list stores.
  * @extends CollectionInterface<TValue>
  * @since 1.0.0

--- a/src/collections/ListIteratorInterface.php
+++ b/src/collections/ListIteratorInterface.php
@@ -6,19 +6,18 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html
  * @link https://github.com/jayroncastro/jfphp
  */
-namespace jayroncastro\jfphp;
+namespace jayroncastro\jfphp\collections;
 
 use Iterator;
 use jayroncastro\jfphp\exception\IndexOutOfBoundsException;
 use jayroncastro\jfphp\exception\NoSuchElementException;
-use ReturnTypeWillChange;
 
 /**
  * An iterator for lists that allows you to traverse the list in any
  * direction, modify the list during iteration, and get the current
  * position of the iterator.
  * @package jayroncastro
- * @subpackage jfphp
+ * @subpackage jfphp/collections
  * @template TValue The type of value the iterator iterates through.
  * @extends Iterator<int, TValue>
  * @since 1.0.0

--- a/src/collections/SetInterface.php
+++ b/src/collections/SetInterface.php
@@ -6,14 +6,14 @@
  * @license https://www.gnu.org/licenses/gpl-3.0.html
  * @link https://github.com/jayroncastro/jfphp
  */
-namespace jayroncastro\jfphp;
+namespace jayroncastro\jfphp\collections;
 
 /**
  * Defines the contract for a collection that guarantees the
  * uniqueness of its elements, extending `CollectionInterface`
  * to enforce a logic that does not allow duplicates.
  * @package jayroncastro
- * @subpackage jfphp
+ * @subpackage jfphp/collections
  * @template TValue
  * @extends CollectionInterface<TValue>
  * @since 1.0.0

--- a/src/core/Field.php
+++ b/src/core/Field.php
@@ -18,16 +18,31 @@ use jayroncastro\jfphp\persistence\PersistenceInterface;
  * compares, and saves it.
  * @package jayroncastro
  * @subpackage jfphp/core
- * @readonly
- * @final
  * @since 1.2.0
  * @version 1.2.0
  */
 final readonly class Field {
 
+    /**
+     * This parameter stores the old value of the field.
+     * @var mixed
+     */
     public mixed $oldValue;
+
+    /**
+     * This parameter stores the new value of the field.
+     * @var mixed
+     */
     public mixed $newValue;
 
+    /**
+     * Class constructor method
+     * @param int $objectId This parameter receives the ID of a field.
+     * @param Request $request This parameter receives an object of type Request.
+     * @param PersistenceInterface $persistence This parameter receives an object
+     * that implements the PersistenceInterface interface.
+     * @param RequestParams $params This parameter receives a RequestParams object.
+     */
     public function __construct(
         private int $objectId,
         private Request $request,
@@ -41,17 +56,59 @@ final readonly class Field {
         $this->newValue = $this->request->getParam( $this->params )->getValue();
     }
 
+    /**
+     * This method returns true if and only if there is a difference
+     * between the old value and the new value.
+     * @return bool
+     */
     public function hasChanged(): bool {
         # Convert to string for safer comparison between different types
         # (e.g. '123' vs. 123)
         return ( string ) $this->oldValue !== ( string ) $this->newValue;
     }
 
+    /**
+     * This method saves the value of this persistence layer field.
+     * @return bool
+     */
     public function save(): bool {
         return $this->persistence->save(
             $this->objectId,
             $this->params->paramName,
             $this->newValue
         );
+    }
+
+    /**
+     * This method deletes the value of this field from the persistence layer.
+     * @return bool
+     */
+    public function delete(): bool {
+        return $this->persistence->delete(
+            $this->objectId,
+            $this->params->paramName
+        );
+    }
+
+    /**
+     * This method checks whether the value has remained unchanged.
+     * @return bool
+     */
+    public function isSame(): bool {
+        return !$this->hasChanged();
+    }
+
+    /**
+     * This method saves the new value to the persistence layer only
+     * if it has changed.
+     * @return bool Returns `True` if the save operation was performed
+     * (because there was a change), and `False` if nothing was done
+     * (because the values were the same).
+     */
+    public function saveIfChanged(): bool {
+        if ( $this->hasChanged() ) {
+            return $this->save();
+        }
+        return false;
     }
 }

--- a/src/core/Field.php
+++ b/src/core/Field.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the small JFPHP Framework.
+ * @author Jayron Castro <eu@jayroncastro.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.html
+ * @link https://github.com/jayroncastro/jfphp
+ */
+namespace jayroncastro\jfphp\core;
+
+use jayroncastro\jfphp\http\Request;
+use jayroncastro\jfphp\http\RequestParams;
+use jayroncastro\jfphp\persistence\PersistenceInterface;
+
+/**
+ * This class manages the entire lifecycle of a field: it gets the
+ * new value from the request, gets the old value from persistence,
+ * compares, and saves it.
+ * @package jayroncastro
+ * @subpackage jfphp/core
+ * @readonly
+ * @final
+ * @since 1.2.0
+ * @version 1.2.0
+ */
+final readonly class Field {
+
+    public mixed $oldValue;
+    public mixed $newValue;
+
+    public function __construct(
+        private int $objectId,
+        private Request $request,
+        private PersistenceInterface $persistence,
+        private RequestParams $params
+    ) {
+        $this->oldValue = $this->persistence->get(
+            $this->objectId,
+            $this->params->paramName
+        );
+        $this->newValue = $this->request->getParam( $this->params )->getValue();
+    }
+
+    public function hasChanged(): bool {
+        # Convert to string for safer comparison between different types
+        # (e.g. '123' vs. 123)
+        return ( string ) $this->oldValue !== ( string ) $this->newValue;
+    }
+
+    public function save(): bool {
+        return $this->persistence->save(
+            $this->objectId,
+            $this->params->paramName,
+            $this->newValue
+        );
+    }
+}

--- a/src/exception/IllegalStateException.php
+++ b/src/exception/IllegalStateException.php
@@ -17,7 +17,6 @@ use RuntimeException;
  * @extends RuntimeException
  * @since 1.0.0
  * @version 1.0.0
- * @final
  */
 final class IllegalStateException extends RuntimeException {
 

--- a/src/exception/IndexOutOfBoundsException.php
+++ b/src/exception/IndexOutOfBoundsException.php
@@ -17,7 +17,6 @@ use Exception;
  * @extends Exception
  * @since 1.0.0
  * @version 1.0.0
- * @final
  */
 final class IndexOutOfBoundsException extends Exception {
 

--- a/src/exception/NoSuchElementException.php
+++ b/src/exception/NoSuchElementException.php
@@ -17,7 +17,6 @@ use RuntimeException;
  * @extends RuntimeException
  * @since 1.0.0
  * @version 1.0.0
- * @final
  */
 final class NoSuchElementException extends RuntimeException {
 

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -17,7 +17,6 @@ namespace jayroncastro\jfphp\http;
  * @subpackage jfphp/http
  * @since 1.0.0
  * @version 1.0.0
- * @final
  */
 final class Request {
 
@@ -106,6 +105,8 @@ final class Request {
      * Checks if a parameter exists in the request.
      * @param string $paramName The name of the parameter to be checked.
      * @return bool Returns `true` if the parameter exists, even if its value is null.
+     * @since 1.1.0
+     * @version 1.1.0
      */
     public function has( string $paramName ): bool {
         return array_key_exists( $paramName, $this->data );

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -17,8 +17,9 @@ namespace jayroncastro\jfphp\http;
  * @subpackage jfphp/http
  * @since 1.0.0
  * @version 1.0.0
+ * @final
  */
-class Request {
+final class Request {
 
     /**
      * The sanitizer object that will be used to sanitize the data.

--- a/src/http/RequestParams.php
+++ b/src/http/RequestParams.php
@@ -18,7 +18,6 @@ use jayroncastro\jfphp\http\enums\DataType;
  * @subpackage jfphp/http
  * @since 1.0.0
  * @version 1.0.0
- * @final
  */
 final readonly class RequestParams {
 

--- a/src/http/result/ArrayResult.php
+++ b/src/http/result/ArrayResult.php
@@ -20,8 +20,6 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @subpackage jfphp/http/result
  * @since 1.0
  * @version 1.0
- * @final
- * @readonly
  */
 final readonly class ArrayResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/ArrayResult.php
+++ b/src/http/result/ArrayResult.php
@@ -21,6 +21,7 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @since 1.0
  * @version 1.0
  * @final
+ * @readonly
  */
 final readonly class ArrayResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/BoolResult.php
+++ b/src/http/result/BoolResult.php
@@ -21,6 +21,7 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @since 1.0
  * @version 1.0
  * @final
+ * @readonly
  */
 final readonly class BoolResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/BoolResult.php
+++ b/src/http/result/BoolResult.php
@@ -20,8 +20,6 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @subpackage jfphp/http/result
  * @since 1.0
  * @version 1.0
- * @final
- * @readonly
  */
 final readonly class BoolResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/EmailResult.php
+++ b/src/http/result/EmailResult.php
@@ -13,7 +13,7 @@ use jayroncastro\jfphp\lang\ValueObject;
 
 /**
  * Implementation of `RequestResult` that immutably encapsulates a
- * value that has been sanitized and validated as a `e-Mail`.
+ * value that has been sanitized and validated as an ` e-Mail `.
  * @extends ValueObject
  * @implements RequestResult
  * @package jayroncastro
@@ -21,6 +21,7 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @since 1.0
  * @version 1.0
  * @final
+ * @readonly
  */
 final readonly class EmailResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/EmailResult.php
+++ b/src/http/result/EmailResult.php
@@ -20,8 +20,6 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @subpackage jfphp/http/result
  * @since 1.0
  * @version 1.0
- * @final
- * @readonly
  */
 final readonly class EmailResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/FloatResult.php
+++ b/src/http/result/FloatResult.php
@@ -21,6 +21,7 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @since 1.0
  * @version 1.0
  * @final
+ * @readonly
  */
 final readonly class FloatResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/FloatResult.php
+++ b/src/http/result/FloatResult.php
@@ -20,8 +20,6 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @subpackage jfphp/http/result
  * @since 1.0
  * @version 1.0
- * @final
- * @readonly
  */
 final readonly class FloatResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/HtmlResult.php
+++ b/src/http/result/HtmlResult.php
@@ -20,8 +20,6 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @subpackage jfphp/http/result
  * @since 1.0
  * @version 1.0
- * @final
- * @readonly
  */
 final readonly class HtmlResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/HtmlResult.php
+++ b/src/http/result/HtmlResult.php
@@ -21,6 +21,7 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @since 1.0
  * @version 1.0
  * @final
+ * @readonly
  */
 final readonly class HtmlResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/IntResult.php
+++ b/src/http/result/IntResult.php
@@ -21,6 +21,7 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @since 1.0
  * @version 1.0
  * @final
+ * @readonly
  */
 final readonly class IntResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/IntResult.php
+++ b/src/http/result/IntResult.php
@@ -20,8 +20,6 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @subpackage jfphp/http/result
  * @since 1.0
  * @version 1.0
- * @final
- * @readonly
  */
 final readonly class IntResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/RawResult.php
+++ b/src/http/result/RawResult.php
@@ -21,6 +21,7 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @since 1.0
  * @version 1.0
  * @final
+ * @readonly
  */
 final readonly class RawResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/RawResult.php
+++ b/src/http/result/RawResult.php
@@ -20,8 +20,6 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @subpackage jfphp/http/result
  * @since 1.0
  * @version 1.0
- * @final
- * @readonly
  */
 final readonly class RawResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/StringResult.php
+++ b/src/http/result/StringResult.php
@@ -20,8 +20,6 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @subpackage jfphp/http/result
  * @since 1.0
  * @version 1.0
- * @final
- * @readonly
  */
 final readonly class StringResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/StringResult.php
+++ b/src/http/result/StringResult.php
@@ -21,6 +21,7 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @since 1.0
  * @version 1.0
  * @final
+ * @readonly
  */
 final readonly class StringResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/TextareaResult.php
+++ b/src/http/result/TextareaResult.php
@@ -21,6 +21,7 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @since 1.0
  * @version 1.0
  * @final
+ * @readonly
  */
 final readonly class TextareaResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/TextareaResult.php
+++ b/src/http/result/TextareaResult.php
@@ -20,8 +20,6 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @subpackage jfphp/http/result
  * @since 1.0
  * @version 1.0
- * @final
- * @readonly
  */
 final readonly class TextareaResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/UrlResult.php
+++ b/src/http/result/UrlResult.php
@@ -21,6 +21,7 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @since 1.0
  * @version 1.0
  * @final
+ * @readonly
  */
 final readonly class UrlResult extends ValueObject implements RequestResult {
 

--- a/src/http/result/UrlResult.php
+++ b/src/http/result/UrlResult.php
@@ -20,8 +20,6 @@ use jayroncastro\jfphp\lang\ValueObject;
  * @subpackage jfphp/http/result
  * @since 1.0
  * @version 1.0
- * @final
- * @readonly
  */
 final readonly class UrlResult extends ValueObject implements RequestResult {
 

--- a/src/persistence/PersistenceInterface.php
+++ b/src/persistence/PersistenceInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of the small JFPHP Framework.
+ * @author Jayron Castro <eu@jayroncastro.com>
+ * @license https://www.gnu.org/licenses/gpl-3.0.html
+ * @link https://github.com/jayroncastro/jfphp
+ */
+namespace jayroncastro\jfphp\persistence;
+
+/**
+ * This interface defines what any "persistence layer" should be
+ * able to do: get, save, and delete a value associated with a
+ * key and an ID.
+ * @package jayroncastro
+ * @subpackage jfphp/persistence
+ * @since 1.2.0
+ * @version 1.2.0
+ */
+interface PersistenceInterface {
+
+    /**
+     * This method gets the value of a field
+     * @param int $objectId This parameter receives the id of a field.
+     * @param string $key This parameter receives the name of a field's key.
+     * @return mixed
+     * @since 1.2.0
+     * @version 1.2.0
+     */
+    public function get( int $objectId, string $key ): mixed;
+
+    /**
+     * This method saves the field value.
+     * @param int $objectId This parameter receives the id of a field.
+     * @param string $key This parameter receives the name of a field's key.
+     * @param mixed $value This parameter receives the value to be stored.
+     * @return bool
+     * @since 1.2.0
+     * @version 1.2.0
+     */
+    public function save( int $objectId, string $key, mixed $value ): bool;
+
+    /**
+     * This method deletes the value of a field.
+     * @param int $objectId This parameter receives the id of a field.
+     * @param string $key This parameter receives the name of a field's key.
+     * @return bool
+     * @since 1.2.0
+     * @version 1.2.0
+     */
+    public function delete( int $objectId, string $key ): bool;
+
+}


### PR DESCRIPTION
## Descrição

Este Pull Request introduz uma nova e poderosa camada de abstração de persistência no framework JFPHP, além de uma classe orquestradora `Field` para gerenciar o ciclo de vida completo de um campo de dados. O objetivo é criar uma forma desacoplada e elegante de obter, comparar e salvar dados, independentemente da sua fonte (ex: metadados do WordPress, uma tabela de banco de dados, etc.).

Adicionalmente, este PR inclui melhorias na organização do código e na documentação para aumentar a clareza e a manutenibilidade do framework.

## Principais Mudanças

### Novas Funcionalidades

* **Implementação da `PersistenceInterface`**:
    * Cria um novo contrato em `jayroncastro/jfphp/persistence/PersistenceInterface`.
    * Define os métodos essenciais `get()`, `save()` e `delete()`, abstraindo a forma como os dados são armazenados e recuperados.

* **Implementação da Classe `Field`**:
    * Adiciona a nova classe `jayroncastro/jfphp/core/Field`.
    * Esta classe atua como um orquestrador de alto nível, utilizando os sistemas de `Request` e `Persistence` para buscar valores antigos e novos, compará-los (`hasChanged()`) e persistir as alterações (`save()`, `delete()`, `saveIfChanged()`).

### Melhorias na Arquitetura e Organização

* **Namespace de Coleções**:
    * Foi criado o novo namespace `jayroncastro/jfphp/collections`.
    * Todas as classes e interfaces relacionadas a coleções (`ArrayList`, `HashSet`, `AbstractCollection`, `ListInterface`, etc.) foram movidas para este novo namespace para melhorar a organização e a coesão do módulo.

* **Atualização de Documentação**:
    * As docstrings (PHPDoc) das classes no namespace `jayroncastro/jfphp/result` foram revisadas e melhoradas para maior clareza.

## Notas Adicionais

Estas alterações representam o conjunto de funcionalidades planejadas para a versão **v1.2.0** do framework.