### PR TITLE
Refactor (BC Break): Injeta o Request no Sistema de Validação para Desacoplamento

### DIFF
--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -18,7 +18,7 @@ use jayroncastro\jfphp\http\validation\ValidatorInterface;
  * @package jayroncastro
  * @subpackage jfphp/http
  * @since 1.0.0
- * @version 1.0.0
+ * @version 2.0.0
  */
 final class Request {
 
@@ -120,13 +120,13 @@ final class Request {
      * @param ValidatorInterface[] $validators This parameter receives an
      * array of validator objects.
      * @return $this Returns the Request instance itself for chaining.
-     * @since 1.3.0
-     * @version 1.3.0
+     * @since 2.0.0
+     * @version 2.0.0
      */
     public function validate( array $validators ): self {
         foreach ( $validators as $validator ) {
             if ( $validator instanceof ValidatorInterface ) {
-                $validator->validate();
+                $validator->validate( $this );
             }
         }
         return $this;

--- a/src/http/validation/ValidatorInterface.php
+++ b/src/http/validation/ValidatorInterface.php
@@ -9,6 +9,7 @@
 namespace jayroncastro\jfphp\http\validation;
 
 use jayroncastro\jfphp\exception\ValidationException;
+use jayroncastro\jfphp\http\Request;
 
 /**
  * This interface defines the contract for classes that validate
@@ -16,14 +17,16 @@ use jayroncastro\jfphp\exception\ValidationException;
  * @package jayroncastro
  * @subpackage jfphp/http/validation
  * @since 1.0.0
- * @version 1.0.0
+ * @version 2.0.0
  */
 interface ValidatorInterface {
 
     /**
      * This method executes the validation logic.
+     * @param Request $request The current request instance.
      * @return void
      * @throws ValidationException If validation fails.
+     * @since 2.0.0
      */
-    public function validate(): void;
+    public function validate( Request $request ): void;
 }


### PR DESCRIPTION
## Descrição

Este Pull Request executa uma refatoração arquitetural crucial no sistema de validação introduzido na `v1.3.0`. O objetivo é eliminar a dependência que os validadores concretos (`WordPressNonceValidator`, etc.) tinham da superglobal `$_POST`, injetando a própria instância da classe `Request` em cada validador.

Esta mudança aumenta significativamente a segurança, a testabilidade e o desacoplamento do framework, alinhando-o com as melhores práticas de injeção de dependência e tornando a API ainda mais robusta e profissional.

## Principais Mudanças (Breaking Change)

⚠️ **ATENÇÃO: Esta é uma mudança que quebra a compatibilidade (Breaking Change).**

A principal alteração está na assinatura do método `validate()` da `ValidatorInterface`:

* **Antes (`v1.3.0`):**
    ```php
    public function validate(): void;
    ```

* **Agora (`v2.0.0`):**
    ```php
    public function validate(Request $request): void;
    ```

**Impacto:**
Qualquer classe que implementava a `ValidatorInterface` da `v1.3.0` precisará ser atualizada para aceitar o parâmetro `$request` em seu método `validate()` para ser compatível com a `v2.0.0`.

## Exemplo de Uso da Nova Arquitetura

Com a nova assinatura, um validador concreto agora acessa os dados da requisição através da API do próprio `Request`, eliminando a necessidade de usar superglobais.

**Exemplo de um `WordPressNonceValidator` refatorado:**
```php
final class WordPressNonceValidator implements ValidatorInterface
{
    // ... construtor ...

    public function validate(Request $request): void
    {
        // Usa o método input() do framework em vez de $_POST
        $nonceValue = $request->input($this->nonceName);

        if (empty($nonceValue) || !wp_verify_nonce($nonceValue, $this->action)) {
            throw new ValidationException('Falha na verificação de segurança (Nonce).');
        }
    }
}
```

## Notas Adicionais

Devido à alteração na assinatura de um método de uma interface pública, esta mudança justifica a incrementação da versão **MAJOR** do framework para **`v2.0.0`**, conforme as regras do Versionamento Semântico.