### PR TITLE
Feature: Adiciona o método de atalho input() à classe Request

### DIFF
--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -8,6 +8,7 @@
  */
 namespace jayroncastro\jfphp\http;
 
+use jayroncastro\jfphp\http\enums\DataType;
 use jayroncastro\jfphp\http\validation\ValidatorInterface;
 
 /**
@@ -53,7 +54,7 @@ final class Request {
     /**
      * Returns a specific request parameter, already sanitized and encapsulated.
      * @param RequestParams $params Object describing the desired parameter.
-     * @return RequestResult Returns a result object with type (e.g. `StringResult`).
+     * @return RequestResult Returns a result object with a type (e.g. `StringResult`).
      */
     public function getParam( RequestParams $params ): RequestResult {
         $rawValue = $this->data[ $params->paramName ] ?? $params->defaultValue;
@@ -130,5 +131,28 @@ final class Request {
             }
         }
         return $this;
+    }
+
+    /**
+     * This method is a shortcut to fetch, sanitize and return the
+     * value of a single parameter; it serves to simplify the call to
+     * getParam, hiding the need to instantiate a RequestParams for
+     * simple use cases.
+     * @param string $paramName The name of the parameter in the request.
+     * @param DataType $dataType The expected data type.
+     * @param mixed|null $defaultValue
+     * @return mixed The final, sanitized value.
+     * @since 2.0.0
+     */
+    public function input(string $paramName,
+                          DataType $dataType = DataType::STRING,
+                          mixed $defaultValue = null): mixed {
+
+        $params = new RequestParams(
+            paramName: $paramName,
+            dataType: $dataType,
+            defaultValue: $defaultValue
+        );
+        return $this->getParam( $params )->getValue();
     }
 }


### PR DESCRIPTION
## Descrição

Este Pull Request adiciona um novo método de conveniência, `input()`, à classe `Request`. A necessidade deste método foi identificada durante a implementação de validadores concretos, onde o acesso a um único parâmetro da requisição precisava ser mais direto e menos verboso.

O método `input()` atua como um atalho para o `getParam()`, escondendo a necessidade de instanciar um objeto `RequestParams` para casos de uso simples e tornando a API do framework mais fluente e expressiva.

## Principais Mudanças

* **`Request.php`**:
    * Adicionado o novo método público `public function input(string $paramName, DataType $dataType = DataType::STRING, mixed $defaultValue = null): mixed`.
    * Este método encapsula a criação do `RequestParams`, a chamada ao `getParam()` e a extração do valor com `getValue()` em uma única operação.

## Exemplo de Uso

A adição deste método simplifica significativamente o código do consumidor do framework.

* **Antes desta mudança:**
    ```php
    $params = new RequestParams('nome_usuario');
    $nome = $request->getParam($params)->getValue();
    ```

* **Com a nova mudança:**
    ```php
    $nome = $request->input('nome_usuario');
    ```

## Notas de Versionamento

Esta alteração adiciona uma nova funcionalidade de forma retrocompatível. Conforme nossa política de versionamento, esta mudança justifica a incrementação da versão **MINOR** para **`v2.1.0`**.